### PR TITLE
Bump dep version for remove async trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all = ["hash", "serde", "stream"]
 [dependencies]
 async-hash = { version = "0.5", optional = true }
 collate = "0.4"
-destream = { version="0.9", optional = true }
+destream = { version = "0.9", optional = true }
 futures = { version = "0.3", optional = true }
 get-size = "0.1"
 get-size-derive = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all = ["hash", "serde", "stream"]
 async-hash = { version = "0.5", optional = true }
 async-trait = "0.1"
 collate = "0.4"
-destream = { path="../destream", optional = true }
+destream = { version="0.9", optional = true }
 futures = { version = "0.3", optional = true }
 get-size = "0.1"
 get-size-derive = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ all = ["hash", "serde", "stream"]
 
 [dependencies]
 async-hash = { version = "0.5", optional = true }
-async-trait = "0.1"
 collate = "0.4"
 destream = { version="0.9", optional = true }
 futures = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "number-general"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["code@tinychain.net"]
 edition = "2021"
 description = "A generic number type for Rust which supports basic math and (de)serialization."
@@ -20,7 +20,7 @@ all = ["hash", "serde", "stream"]
 async-hash = { version = "0.5", optional = true }
 async-trait = "0.1"
 collate = "0.4"
-destream = { git = "https://github.com/drewmcarthur/destream.git", branch = "add-derivability", optional = true }
+destream = { path="../destream", optional = true }
 futures = { version = "0.3", optional = true }
 get-size = "0.1"
 get-size-derive = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all = ["hash", "serde", "stream"]
 async-hash = { version = "0.5", optional = true }
 async-trait = "0.1"
 collate = "0.4"
-destream = { version = "0.8", optional = true }
+destream = { git = "https://github.com/drewmcarthur/destream.git", branch = "add-derivability", optional = true }
 futures = { version = "0.3", optional = true }
 get-size = "0.1"
 get-size-derive = "0.1"

--- a/src/destream.rs
+++ b/src/destream.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use destream::de::{self, Decoder, FromStream, Visitor};
 use destream::en::{EncodeSeq, Encoder, IntoStream, ToStream};
 use futures::TryFutureExt;
@@ -7,7 +6,6 @@ use super::{
     Boolean, Complex, Float, Int, Number, NumberVisitor, UInt, _Complex, ERR_COMPLEX, ERR_NUMBER,
 };
 
-#[async_trait]
 impl FromStream for Boolean {
     type Context = ();
 
@@ -31,7 +29,6 @@ impl<'en> IntoStream<'en> for Boolean {
     }
 }
 
-#[async_trait]
 impl FromStream for Complex {
     type Context = ();
 
@@ -39,7 +36,7 @@ impl FromStream for Complex {
         cxt: Self::Context,
         decoder: &mut D,
     ) -> Result<Self, D::Error> {
-        let [re, im]: [f64; 2] = FromStream::from_stream(cxt, decoder).await?;
+        let [re, im]: [f64; 2] = <[f64; 2] as FromStream>::from_stream(cxt, decoder).await?;
         Ok(num::Complex::new(re, im).into())
     }
 }
@@ -82,7 +79,6 @@ impl<'en> IntoStream<'en> for Complex {
     }
 }
 
-#[async_trait]
 impl FromStream for Float {
     type Context = ();
 
@@ -112,7 +108,6 @@ impl<'en> IntoStream<'en> for Float {
     }
 }
 
-#[async_trait]
 impl FromStream for Int {
     type Context = ();
 
@@ -146,7 +141,6 @@ impl<'en> IntoStream<'en> for Int {
     }
 }
 
-#[async_trait]
 impl FromStream for UInt {
     type Context = ();
 
@@ -180,7 +174,6 @@ impl<'en> IntoStream<'en> for UInt {
     }
 }
 
-#[async_trait]
 impl Visitor for NumberVisitor {
     type Value = Number;
 
@@ -266,7 +259,6 @@ impl Visitor for NumberVisitor {
     }
 }
 
-#[async_trait]
 impl FromStream for Number {
     type Context = ();
 


### PR DESCRIPTION
Bumps `destream` dependency to `0.9` and removes requirements for `async_trait`

todo before merging:
- [x] make sure `destream_json` works & compiles

also, @haydnv let me know if there's a version-branch (e.g. `0.13`) you'd like me to merge this into instead.